### PR TITLE
Add GND net to pad 2

### DIFF
--- a/src/footprints/promicro_pretty.js
+++ b/src/footprints/promicro_pretty.js
@@ -730,7 +730,7 @@ module.exports = {
           (xy 0.6 -0.4) (xy -0.6 -0.4) (xy -0.6 -0.2) (xy 0 0.4) (xy 0.6 -0.2)
   ) (width 0))
       ))
-    (pad 2 smd custom (at -11.43 4.826 ${p.rot + 180}) (size 1.2 0.5) (layers B.Cu B.Mask)
+    (pad 2 smd custom (at -11.43 4.826 ${p.rot + 180}) (size 1.2 0.5) (layers B.Cu B.Mask) ${p.net.GND.str}
       (clearance 0.1) (zone_connect 0)
       (options (clearance outline) (anchor rect))
       (primitives


### PR DESCRIPTION
The pad 2 of the promicro_pretty footprint is does not have the GND net as it should, this commit fixes that.

But it is connected to ground either way, this just makes is more correct.

![image](https://user-images.githubusercontent.com/14265358/187059267-c522388d-746f-4793-a705-68d04285d150.png)
